### PR TITLE
Update hashcode calculation in HashSet collection example

### DIFF
--- a/samples/snippets/csharp/VS_Snippets_CLR_System/system.Collections.Generic.HashSet_ExceptWith/cs/source2.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR_System/system.Collections.Generic.HashSet_ExceptWith/cs/source2.cs
@@ -86,7 +86,7 @@ class SameVehicleComparer : EqualityComparer<string>
 
     public override int GetHashCode(string s)
     {
-        return base.GetHashCode();
+        return s.ToLower().GetHashCode();
     }
 }
 


### PR DESCRIPTION
# Update hashcode calculation in HashSet collection example

## Summary

This example only works because there is a mistake and instead of string hashcode you take comparator object hash

Fixes #4291

## Details

https://github.com/dotnet/docs/issues/4291
